### PR TITLE
DHM gage parser

### DIFF
--- a/subroutines_CCHF_specific/supporting_fun/read_write_gage_data/read_DHM_data.m
+++ b/subroutines_CCHF_specific/supporting_fun/read_write_gage_data/read_DHM_data.m
@@ -1,0 +1,105 @@
+function [data, date] = read_DHM_data(path)
+%read_DHM_data reads streamgage data from Nepal DHM
+%
+% Input
+%   path - complete path and filename to DHM streamgage file
+%
+% Optional Input n/a
+%   
+% Output
+%   data - numDays X 1 numeric array of daily flow data, units = m^3/s
+%   date = numDays X 3 numberic array of year, month, day
+%
+% Notes
+% This function parses streamgage data obtained from the Nepal Government
+% Department of Hydrology and Meteorology and reformats in a format
+% expected by CCHF.
+%
+% DHM data includes confidence intervals and possibly multiple 
+% measurements per day.  CCHF expects one flow value per day.
+%
+% Reads multi-column DHM data, ignoring lowerBound and upperBound
+% measurements, and averaging meanDischarge values for any days with
+% more than one measurement.
+%
+% TODO: Currently missing dates are passed through, do they need to
+% be filled with NaNs?
+%
+% Throws errors if:
+%   Input file is not .csv
+%   File does not contain expected column names from DHM
+% 
+% Example
+% [data, date] = read_DHM_data('/path/to/gage_from_DHM.csv');
+%
+
+% Copyright 2019 Thomas M. Mosier and the Regents of the University
+% of Colorado
+%
+% This file is part of multiple packages, including the GlobalClimateData 
+% Downscaling Package, the Hydropower Potential Assessment Tool, and the 
+% Conceptual Cryosphere Hydrology Framework.
+% 
+% The above named packages are free software: you can 
+% redistribute it and/or modify it under the terms of the GNU General 
+% Public License as published by the Free Software Foundation, either 
+% version 3 of the License, or (at your option) any later version.
+% 
+% The above named packages are distributed in the hope that it will be 
+% useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+% Public License for more details.
+% 
+% You should have received a copy of the GNU General Public License
+% along with the Downscaling Package.  If not, see 
+% <http://www.gnu.org/licenses/>.
+%
+
+sepDate = {'\','/','-',':'};
+
+[~, ~, extGage] = fileparts(path);
+
+if regexpbl(extGage,{'csv'})  
+
+    fprintf("%s: Reading csv file %s", mfilename(), path);
+    T = readtable(path);
+    
+    % Confirm that data columns are what we are expecting from DHM
+    % N.B. this logical depends on readtable behavior that collapses
+    % whitespace in column headers
+    if ~all(ismember(T.Properties.VariableNames, ...
+            {'Date', 'Time', 'lowerBound', ...
+            'meanDischarge', 'upperBound'}))
+        error("%s: ERROR: DHM file %s does not contain expected columns", ...
+            mfilename(), path);
+    end
+    
+    % Drop the confidence interval columns we will ignore
+    % This feature is only available beginning with Matlab r2018a
+    T.lowerBound = [];
+    T.upperBound = [];
+    
+    % Find any dates with multiple values and
+    % average them
+    [G, TID] = findgroups(T(:,'Date'));
+    dailyDischarge = splitapply(@mean, T(:, 'meanDischarge'), G);
+    dailyData = table(TID, dailyDischarge);
+    
+    % Extract date parts
+    yyyy = year(dailyData{:, "TID"}.Date);
+    mm = month(dailyData{:, "TID"}.Date);
+    dd = day(dailyData{:, "TID"}.Date);
+    
+    dailyData = [dailyData, table(yyyy), table(mm), table(dd)];
+    
+    % And reformat to expected output numeric matrices
+    data = table2array(dailyData(:,"dailyDischarge"));
+    date = table2array(dailyData(:,{'yyyy' 'mm' 'dd'}));
+    
+    fprintf("next");
+    
+else
+    error("%s: ERROR: DHM file %s in unknownFormat: %s\n", ...
+        mfilename(), path, extGage);
+end
+

--- a/subroutines_CCHF_specific/supporting_fun/read_write_gage_data/read_DHM_data.m
+++ b/subroutines_CCHF_specific/supporting_fun/read_write_gage_data/read_DHM_data.m
@@ -85,18 +85,29 @@ if regexpbl(extGage,{'csv'})
     dailyDischarge = splitapply(@mean, T(:, 'meanDischarge'), G);
     dailyData = table(TID, dailyDischarge);
     
-    % Extract date parts
-    yyyy = year(dailyData{:, "TID"}.Date);
-    mm = month(dailyData{:, "TID"}.Date);
-    dd = day(dailyData{:, "TID"}.Date);
+    % Set any dates with missing discharge data to NaN
+    startDate = dailyData{1, "TID"}.Date;
+    endDate = dailyData{height(dailyData), "TID"}.Date;
+    date = (startDate:endDate)';
+    discharge = NaN([numel(date) 1]);
+    allData = [table(date), table(discharge)];
+
+    for i=1:height(dailyData)
+        nextDate = dailyData{i, "TID"}.Date;
+        nextDischarge = dailyData{i, "dailyDischarge"};
+        allData(allData.date == nextDate, :).discharge = nextDischarge;
+    end
+
+    yyyy = year(allData.date);
+    mm = month(allData.date);
+    dd = day(allData.date);
     
-    dailyData = [dailyData, table(yyyy), table(mm), table(dd)];
+    % Extract date parts    
+    allData = [allData, table(yyyy), table(mm), table(dd)];
     
     % And reformat to expected output numeric matrices
-    data = table2array(dailyData(:,"dailyDischarge"));
-    date = table2array(dailyData(:,{'yyyy' 'mm' 'dd'}));
-    
-    fprintf("next");
+    data = table2array(allData(:,"discharge"));
+    date = table2array(allData(:,{'yyyy' 'mm' 'dd'}));
     
 else
     error("%s: ERROR: DHM file %s in unknownFormat: %s\n", ...

--- a/subroutines_CCHF_specific/supporting_fun/read_write_gage_data/test_read_gagedata.m
+++ b/subroutines_CCHF_specific/supporting_fun/read_write_gage_data/test_read_gagedata.m
@@ -1,0 +1,19 @@
+%
+%test script for new DHM format streamgage data at
+%read_gagedata level.  Output should be a valid CCHF-formatted file.
+%
+%list = dir(['/pl/active/PMESDR/CCHF_data/assessment_sites/Donyian/' ...
+%    'observations/Donyian_streamflow_measurement_info/*.xlsx']);
+list = dir(['/pl/active/PMESDR/CCHF_data/assessment_sites/Langtang/' ...
+    'observations/langtang_streamgage/*DHM*.csv']);
+
+inFileName = fullfile(list.folder, list.name);
+fprintf(inFileName);
+lon = linspace(85., 86., 10)
+lat = linspace(28., 29., 10);
+
+sObs = read_gagedata(inFileName, lon, lat)
+
+fprintf("test");
+
+ 

--- a/subroutines_CCHF_specific/supporting_fun/read_write_gage_data/test_read_ts_table_data.m
+++ b/subroutines_CCHF_specific/supporting_fun/read_write_gage_data/test_read_ts_table_data.m
@@ -1,0 +1,17 @@
+%
+%test script for new DHM format streamgage data
+%
+%list = dir(['/pl/active/PMESDR/CCHF_data/assessment_sites/Donyian/' ...
+%    'observations/Donyian_streamflow_measurement_info/*.xlsx']);
+list = dir(['/pl/active/PMESDR/CCHF_data/assessment_sites/Langtang/' ...
+    'observations/langtang_streamgage/*DHM*.csv']);
+
+inFileName = fullfile(list.folder, list.name);
+unitsIn = 'm3/s';
+fprintf(inFileName);
+
+
+[data, date] = read_ts_table_data(inFileName, unitsIn);
+fprintf("test");
+
+ 


### PR DESCRIPTION
Thomas,
I've got a new DHM gage parser working, calling it from read_ts_table_data.m if file name contains "DHM" and extension is .csv--do you think these are the correct criteria to avoid conflicts with any other gage data?

Also, I wrote it to ignore the DHM confidence intervals and average measurements for any days with multiple entries.  So it's outputting 1 measurement per day.

However, I notice in the Langtang file that there are gaps in data, for e.g. a big gap from March 23 to May 1 for 2014--no measurements at all.  Current behavior is to pass through data with any gaps.  An alternative could be to add entries for any missing days, with data value of NaN--or some other fill value.  How do you want this to be handled?

Lastly, I noticed Matlab help is only returning the Copyright notice on your .m files, so I moved the function definition to first line in the file and added usage comments that will now be returned when you query for Function Help.  This is clearly breaking your documentation convention, so let me know if you prefer that I not do this in future.