### PR TITLE
Moved check for calibration_resume.

### DIFF
--- a/subroutines_CCHF_specific/modular_engine/CCHF_implement.m
+++ b/subroutines_CCHF_specific/modular_engine/CCHF_implement.m
@@ -146,24 +146,6 @@ if sMeta.useprevrun == 0
                 sPath{ii}.('coef')   = blanks(0);
             sHydro{ii} = struct;
 
-            %Load folder of previous calibration run that was interrupted
-            if ii == 1 && regexpbl(sMeta.runType, {'calib','resume'}, 'and')
-                if isempty(sMeta.pathresume)
-                    uiwait(msgbox(sprintf(['Select the folder containing '...
-                        'the unfinished calibration state file for ' sMeta.region{ii} '.\n']), ...
-                        '(Click OK to Proceed)','modal'));
-                    sPath{ii}.resume = uigetdir(startPath,['Select the folder containing '...
-                        'the unfinished calibration state file for ' sMeta.region{ii}]);
-                else
-                    if isfolder(sMeta.pathresume)
-                        pathResume = sMeta.pathresume;
-                    elseif isfile(sMeta.pathresume)
-                        [pathResume, ~, ~] = fileparts(sMeta.pathresume);
-                    end
-                    sPath{ii}.resume = pathResume;
-                end
-            end
-
             %Digital Elevation Model (DEM) selection and display:
             uiwait(msgbox(sprintf(['Select the Digital Elevation Model (DEM) for ' ...
                 sMeta.region{ii} '.\n']), '(Click OK to Proceed)','modal'));
@@ -337,6 +319,25 @@ if sMeta.useprevrun == 0
 
         %Create unique 'main' output directory based upon inputs:
         if ii == 1   
+
+            %Load folder of previous calibration run that was interrupted
+            if regexpbl(sMeta.runType, {'calib','resume'}, 'and')
+                if isempty(sMeta.pathresume)
+                    uiwait(msgbox(sprintf(['Select the folder containing '...
+                        'the unfinished calibration state file for ' sMeta.region{ii} '.\n']), ...
+                        '(Click OK to Proceed)','modal'));
+                    sPath{ii}.resume = uigetdir(startPath,['Select the folder containing '...
+                        'the unfinished calibration state file for ' sMeta.region{ii}]);
+                else
+                    if isfolder(sMeta.pathresume)
+                        pathResume = sMeta.pathresume;
+                    elseif isfile(sMeta.pathresume)
+                        [pathResume, ~, ~] = fileparts(sMeta.pathresume);
+                    end
+                    sPath{ii}.resume = pathResume;
+                end
+            end
+
             if isfield(sPath{ii},'resume')
                 foldOutputMain = sPath{ii}.resume;
                 [~, sMeta.strModule] = CCHF_out_dir(sPath{ii}, sMeta);

--- a/subroutines_CCHF_specific/optimization/apso.m
+++ b/subroutines_CCHF_specific/optimization/apso.m
@@ -25,7 +25,7 @@ function coefN = apso(coef, fitScore, prmBnds, iter, varargin)
 persistent vel lrnRt state
 
 %Check if persistent variable empty (just initialized)
-if any(isempty(vel), isempty(lrnRt), isempty(state))
+if any([isempty(vel), isempty(lrnRt), isempty(state)])
     varEmpty = 1;
 else
     varEmpty = 0;

--- a/subroutines_CCHF_specific/optimization/coef_next_gen.m
+++ b/subroutines_CCHF_specific/optimization/coef_next_gen.m
@@ -70,7 +70,7 @@ elseif regexpbl(sOpt.type,{'hybrid'})
 elseif strcmpi(sOpt.type, 'pso') || regexpbl(sOpt.type, 'particle swarm')
     coef = pso(coef, fitScore, prmBnds, ii);
 elseif strcmpi(sOpt.type, 'apso')
-    coef = apso(coef, fitScore, prmBnds, ii, 'path', sOpt.dirSave);
+    coef = apso(coef, fitScore, prmBnds, ii, 'pathSave', sOpt.dirSave);
 elseif regexpbl(sOpt.type,{'Uniform','sampling'},'and')
     %Do nothing because all parameter sets have already been defined
 elseif regexpbl(sOpt.type,{'Monte','Carlo'},'and')


### PR DESCRIPTION
Moved the check of calibration_resume outside block that uses GUI
to get inputs.  This allows defining file with input paths and
the location to resume working directly from input main
script (without GUI inputs).